### PR TITLE
ci: push release tag explicitly so GitHub release step succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,9 @@ jobs:
         run: |
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v${NEW_VERSION}"
-          git tag "v${NEW_VERSION}"
-          git push origin main --follow-tags
+          git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+          git push origin main
+          git push origin "v${NEW_VERSION}"
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
## Problem

The `v2.0.1` release run published to the Marketplace successfully but failed at **Create GitHub release** with:

> tag v2.0.1 exists locally but has not been pushed to eridem/vscode-nupkg

## Cause

The workflow created a **lightweight** tag (`git tag "v${NEW_VERSION}"`) and pushed with `git push origin main --follow-tags`. `--follow-tags` only pushes **annotated** tags, so the tag never reached the remote and `gh release create` aborted.

## Fix

Make the tag annotated and push it explicitly:

```diff
-          git tag "v${NEW_VERSION}"
-          git push origin main --follow-tags
+          git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+          git push origin main
+          git push origin "v${NEW_VERSION}"
```

The `v2.0.1` release was completed manually (tag pushed, GitHub release created with the `.vsix`); this only prevents recurrence on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)